### PR TITLE
Should allow user to send custom input fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ NodeMailForm is a simple server side script for receiving form posts and emailin
 
 Make sure to update the `action` url to be your Heroku app url, and the key should be `ADMIN` or a custom key that matches your config variables.
 
+## Advanced Usage
+
+You can add custom fields to be added to the end of your email message. Usefull for address, phone number, etc. All you have to do is set the input name to `_fields.` followed by a camel case sentence.
+
+    <input type="tel" name="_fields.cellNumber">
+
+The above code will result in the following appended to the end of your email message:
+
+    Cell number: ### ### ####
+
 ## Contributing
 
 Please feel free to create an issue with any bugs you find or any improvements you would like to share. Pull requests for new features are also very welcome!

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "body-parser": "^1.10.2",
     "express": "^4.11.1",
+    "lodash": "^3.3.1",
     "mandrill-api": "^1.0.41",
     "multer": "^0.1.7",
     "nconf": "^0.7.1"

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ var bodyParser = require('body-parser');
 var multer = require('multer'); 
 var mandrill = require('mandrill-api/mandrill');
 var nconf = require('nconf');
+var _ = require('lodash');
 
 var config = nconf
   .argv()
@@ -36,9 +37,23 @@ app.post('/', function(req, res) {
     return;
   }
 
+  //  Construct Message
+  var emailMessage = req.body.message;
+
+  //  Create string of _fields elements to add at end of message
+  if (emailMessage) {
+    emailMessage += '\r\n\r\n';
+  }
+
+  _.forIn(req.body, function(value, key) {
+    if (/^\_fields\.*/.test(key)) {
+      emailMessage += key + ': ' + value + '\r\n';
+    }
+  });
+
   //  Create an email message based on post values
   var message = {
-    'text': req.body.message || 'No message was provided',
+    'text': emailMessage || 'No message was provided',
     'subject': req.body._subject || 'Email from NodeMailForm',
     'from_email': req.body._replyto,
     'from_name': req.body.name,

--- a/server.js
+++ b/server.js
@@ -47,6 +47,14 @@ app.post('/', function(req, res) {
 
   _.forIn(req.body, function(value, key) {
     if (/^\_fields\.*/.test(key)) {
+      //  Make the key into a pretty sentence
+      //  (e.g. _fields.hiThere => Hi there)
+      var key = key
+        .replace('_fields.', '')
+        .replace(/^[a-z]|[A-Z]/g, function(v, i) {
+          return i === 0 ? v.toUpperCase() : " " + v.toLowerCase();
+        });
+
       emailMessage += key + ': ' + value + '\r\n';
     }
   });


### PR DESCRIPTION
Users can now add custom form inputs to their form and have the values appended to the end of the email message. Input field name must start with `_fields.` followed by a camel case sentence `cellNumber`.

    <input type="tel" name="_fields.cellNumber">

Will result in the following at the end of the email:

    Cell number: ### ### ####

Resolves #13